### PR TITLE
fix(test): swap exception production types

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: 17
-          distribution: 'zulu' # Alternative distribution options are available
+          distribution: 'temurin' # Alternative distribution options are available
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:

--- a/core/src/test/groovy/com/remoteguardian/RemoteGuardianExceptionSpec.groovy
+++ b/core/src/test/groovy/com/remoteguardian/RemoteGuardianExceptionSpec.groovy
@@ -9,7 +9,7 @@ class RemoteGuardianExceptionSpec extends Specification {
     void "test RemoteGuardianException"() {
         when:
         try {
-            Math.divideExact(1,0)
+            new java.io.File(null as String)
         } catch (Exception e) {
             throw new RemoteGuardianException("this is a test", e)
         }
@@ -17,13 +17,13 @@ class RemoteGuardianExceptionSpec extends Specification {
         then:
         def error = thrown(RemoteGuardianException)
         error.message == "this is a test"
-        error.cause.class == ArithmeticException.class
+        error.cause.class == NullPointerException.class
     }
 
     void "test RemoteGuardianException with message"() {
         when:
         try {
-            Math.divideExact(1,0)
+            new java.io.File(null as String)
         } catch (Exception ignored) {
             throw new RemoteGuardianException("this is a test")
         }


### PR DESCRIPTION
locally testing off graalvm jdk causes errors when ci is testing against zulu jdk. change all to temurin.